### PR TITLE
Fixing warnings and project configurations

### DIFF
--- a/Development/Client/Client.vcxproj
+++ b/Development/Client/Client.vcxproj
@@ -74,6 +74,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\EvayrNet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -94,6 +95,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\EvayrNet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Development/EvayrNet/EvayrNet.vcxproj
+++ b/Development/EvayrNet/EvayrNet.vcxproj
@@ -59,13 +59,13 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -78,7 +78,7 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -107,7 +107,7 @@
     <IntDir>$(Platform)\bin\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)\bin$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>$(SolutionDir)\bin\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\bin\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -115,6 +115,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>.\include;E:\Software\Visual Leak Detector\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -132,6 +133,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Development/EvayrNet/EvayrNet.vcxproj
+++ b/Development/EvayrNet/EvayrNet.vcxproj
@@ -115,7 +115,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\include;E:\Software\Visual Leak Detector\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -123,7 +123,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\include;E:\Software\Visual Leak Detector\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Development/EvayrNet/include/data/stream/DataStreamReader.h
+++ b/Development/EvayrNet/include/data/stream/DataStreamReader.h
@@ -23,6 +23,10 @@ namespace EvayrNet
 		void Read(std::string& aVar);
 		void Read(float& aVar);
 		void Read(double& aVar);
+		void Read(int16_t& aVar);
+		void Read(int8_t& aVar);
+		void Read(uint16_t& aVar);
+		void Read(uint8_t& aVar);
 
 		void SkipBytes(uint32_t aLength);
 

--- a/Development/EvayrNet/include/data/stream/DataStreamWriter.h
+++ b/Development/EvayrNet/include/data/stream/DataStreamWriter.h
@@ -23,6 +23,10 @@ namespace EvayrNet
 		void Write(const std::string& acVar);
 		void Write(const float& acVar);
 		void Write(const double& acVar);
+		void Write(const int16_t& acVar);
+		void Write(const int8_t& acVar);
+		void Write(const uint16_t& acVar);
+		void Write(const uint8_t& acVar);
 
 	private:
 		std::string& m_DataStream;

--- a/Development/EvayrNet/src/connection/Connection.cpp
+++ b/Development/EvayrNet/src/connection/Connection.cpp
@@ -354,7 +354,7 @@ bool EvayrNet::Connection::SequenceIsNewer(uint8_t aID) const
 
 void Connection::UpdateLifetime()
 {
-	if (!m_Active) return;
+	if (!m_Active && !g_Network->IsConnected()) return;
 
 	if (uint32_t(clock() - m_PingClock) > m_ConnectionTimeout)
 	{

--- a/Development/EvayrNet/src/data/stream/DataStreamReader.cpp
+++ b/Development/EvayrNet/src/data/stream/DataStreamReader.cpp
@@ -42,6 +42,30 @@ void DataStreamReader::Read(double& aVar)
 	m_ReadPosition += sizeof(double);
 }
 
+void EvayrNet::DataStreamReader::Read(int16_t& aVar)
+{
+	memcpy(((uint8_t*)&aVar), &m_DataStream[m_ReadPosition], sizeof(int16_t));
+	m_ReadPosition += sizeof(int16_t);
+}
+
+void EvayrNet::DataStreamReader::Read(int8_t& aVar)
+{
+	memcpy(((uint8_t*)&aVar), &m_DataStream[m_ReadPosition], sizeof(int8_t));
+	m_ReadPosition += sizeof(int8_t);
+}
+
+void EvayrNet::DataStreamReader::Read(uint16_t& aVar)
+{
+	memcpy(((uint8_t*)&aVar), &m_DataStream[m_ReadPosition], sizeof(uint16_t));
+	m_ReadPosition += sizeof(uint16_t);
+}
+
+void EvayrNet::DataStreamReader::Read(uint8_t& aVar)
+{
+	memcpy(((uint8_t*)&aVar), &m_DataStream[m_ReadPosition], sizeof(uint8_t));
+	m_ReadPosition += sizeof(uint8_t);
+}
+
 void DataStreamReader::SkipBytes(uint32_t aLength)
 {
 	m_ReadPosition += aLength;

--- a/Development/EvayrNet/src/data/stream/DataStreamWriter.cpp
+++ b/Development/EvayrNet/src/data/stream/DataStreamWriter.cpp
@@ -33,3 +33,23 @@ void DataStreamWriter::Write(const double& acVar)
 {
 	WriteRaw((const uint8_t*)&acVar, sizeof(double));
 }
+
+void EvayrNet::DataStreamWriter::Write(const int16_t& acVar)
+{
+	WriteRaw((const uint8_t*)&acVar, sizeof(int16_t));
+}
+
+void EvayrNet::DataStreamWriter::Write(const int8_t& acVar)
+{
+	WriteRaw((const uint8_t*)&acVar, sizeof(int8_t));
+}
+
+void DataStreamWriter::Write(const uint16_t& acVar)
+{
+	WriteRaw((const uint8_t*)&acVar, sizeof(uint16_t));
+}
+
+void DataStreamWriter::Write(const uint8_t& acVar)
+{
+	WriteRaw((const uint8_t*)&acVar, sizeof(uint8_t));
+}

--- a/Development/Server/Server.vcxproj
+++ b/Development/Server/Server.vcxproj
@@ -74,6 +74,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\EvayrNet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -91,6 +92,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\EvayrNet\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Development/codegen.py
+++ b/Development/codegen.py
@@ -207,15 +207,14 @@ def EndMessage(messageName, opcode):
 			cpp.write(stringPreLines[strpi])
 			strpi += 1
 		cpp.write(newline)
-	cpp.write(tab + "return " + str(packetSize + headerSize))
+	cpp.write(tab + "return uint16_t(" + str(packetSize + headerSize))
 	stri = 0;
 	while stri < len(stringLines):
 		cpp.write(stringLines[stri])
 		stri += 1
-	if len(stringPreLines) == 0:
-		cpp.write(";\n")
-	else:
-		cpp.write(" + arraysSize;\n")
+	if len(stringPreLines) != 0:
+		cpp.write(" + arraysSize")
+	cpp.write(");\n")
 	cpp.write("}\n")
 	cpp.write(newline)
 	cpp.write("uint8_t " + messageName + "::GetMessageOpcode()\n")


### PR DESCRIPTION
Project configurations were wrongly configured on some configurations, resulting the library being compiled as a .exe instead of a .lib. This has now been fixed for both Debug and Release on both Win32 and x64.

There were some warnings like truncation errors during (de)serializing of data. Another potential warning was that the generated GetMessageSize() function generated by the codegen.py would've been returning a size_t instead of a uint16_t. This also has been fixed.